### PR TITLE
chore(security): add pinned least-privilege CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: codeql
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1"
+permissions:
+  contents: read
+jobs:
+  analyze:
+    name: analyze python
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          languages: python
+          build-mode: none
+      - uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
Adds continuous CodeQL (Python) SAST — on push/PR + weekly — closing the `no analysis found` gap. Actions SHA-pinned; job-scoped `security-events: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)